### PR TITLE
fix: add certifi to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto3 >= 1.12.6
 inquirer >= 2.6.3
 python-dateutil >=2.8.1
+certifi >= 2021.10


### PR DESCRIPTION
Adding certifi to make it easier to load the Zscaler cert to python’s certificates bundle for dev setup.

Once the user has a local copy of the cert (e.g. in `~/.ssl`) they can call:

```
cat ~/.ssl/zscaler.crt >> $(python3 -m certifi)
```

As opposed to finding the right cacert.pem from the list and possibly pasting in the wrong one.